### PR TITLE
Switch endPoint to endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Encpsulate all your commands within a **payload** object.
     node: 2,
     class: "BinarySwitch",
     operation:"Set",
-    endPoint:1, // zero based index. 0 - First outlet, 1 - second outlet and so on.
+    endpoint:1, // zero based index. 0 - First outlet, 1 - second outlet and so on.
     params: [true]
   }
 }

--- a/zwave-js/zwave-js.js
+++ b/zwave-js/zwave-js.js
@@ -203,7 +203,7 @@ module.exports = function (RED) {
             let Operation = msg.payload.operation
             let Class = msg.payload.class;
             let Node = msg.payload.node;
-            let Params = msg.payload.params;
+            let Params = msg.payload.params || [];
 
             let ReturnNode = { id: Node };
 

--- a/zwave-js/zwave-js.js
+++ b/zwave-js/zwave-js.js
@@ -230,8 +230,10 @@ module.exports = function (RED) {
 
             let EP = 0;
 
-            if (msg.payload.hasOwnProperty("endPoint")) {
-                EP = parseInt(msg.payload.endPoint)
+            if (msg.payload.hasOwnProperty("endpoint")) {
+              EP = parseInt(msg.payload.endpoint)
+            } else if (msg.payload.hasOwnProperty("endPoint")) {
+              EP = parseInt(msg.payload.endPoint)
             }
 
             if (Func.hasOwnProperty("ParamEnumDependency")) {


### PR DESCRIPTION
Code still checks for `endPoint` as backup (for deprecation purposes)