### PR TITLE
Bugfix proper logger fn ref

### DIFF
--- a/zwave-js/zwave-js.js
+++ b/zwave-js/zwave-js.js
@@ -433,7 +433,7 @@ module.exports = function (RED) {
                 res.json(a);
             },
             err => {
-                node.log('Error listing serial ports', err)
+                RED.eventLog.log('Error listing serial ports', err)
             }
         )
     });


### PR DESCRIPTION
This fixes a (pretty significant) bug that currently crashes Node-RED if the node is unable to list serial ports.

```
ReferenceError: node is not defined
    at /config/node-red/node_modules/node-red-contrib-zwave-js/zwave-js/zwave-js.js:436:17
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
```

The code cannot reference `node` because it is outside its scope. We can use `RED.eventLog.log()`, as used in this PR. Or you can go with a `console.log()` or `console.error()`